### PR TITLE
[Q3.기능개발]-박효원

### DIFF
--- a/src/Q3/hyowon/Solution.java
+++ b/src/Q3/hyowon/Solution.java
@@ -1,0 +1,64 @@
+package Q3.hyowon;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+class Solution {
+    public static void main(String[] args) {
+        // case 1
+        int[] progresses1 = {93, 30, 55};
+        int[] speeds1     = {1, 30, 5};
+        solution(progresses1,speeds1);
+
+        // case 2
+        int[] progresses2 = {93, 30, 55, 1, 99};
+        int[] speeds2     = {1,  30, 5,  1, 100};
+        solution(progresses2,speeds2);
+    }
+
+    public static int[] solution(int[] progresses, int[] speeds) {
+        // 평균 수행시간 1.7ms
+        HashMap<Integer, Integer> workQuantity = new HashMap<>();
+        int workingDay;
+        int releaseDay = 0;
+        int index = -1;
+
+        // 시간복잡도 O(n)
+        for (int i = 0; i < progresses.length; i++) {
+            workingDay = calculateWorkingDay(i, progresses, speeds);
+
+            // (작업진도가 1, 작업속도가 1인 경우) 최장 workingDay는 99일이니 이 기능 이후로는 모두 99일째에 배포된다.
+            // 그러나 이 코드가 추가되었다고 해서 채점시 수행시간이 유의미하게 줄진 않는다.
+            if (workingDay == 99) {
+                workQuantity.put(++index, progresses.length - i);
+                break;
+            }
+
+            if (workingDay > releaseDay) {
+                releaseDay = workingDay;
+                workQuantity.put(++index, 1);
+            } else {
+                workQuantity.put(index, workQuantity.get(index) + 1);
+            }
+        }
+
+        // 시간복잡도 O(n)
+        return IntegerMapToArray(workQuantity);
+    }
+
+    static int calculateWorkingDay(int idx, int[] progresses, int[] speeds) {
+        double workingDay = (100 - progresses[idx]) / (double) speeds[idx];
+        return (int) Math.ceil(workingDay);
+    }
+
+    static int[] IntegerMapToArray(HashMap<Integer, Integer> map) {
+        int[] intArray = new int[map.size()];
+        for (int i = 0; i < map.size(); i++) {
+            intArray[i] = map.get(i);
+        }
+        return intArray;
+    }
+
+}


### PR DESCRIPTION
#22 문제 해결하였습니다.
시간복잡도 O(2n)
각 기능의 필요개발일자(workingDay)를 계산하여,  
배열을 돌면서 더 큰 작업일자가 나오기 전까지는 같이 배포되도록 카운트합니다.

최대 workingDay(99일)가 나온다면 그 뒤의 작업들은 모두 같은 날 배포되는 점을 고려해 그 뒤로 배열 도는걸 멈췄지만
배열의 최대 size가 100이라 성능상 효과는 없었습니다.